### PR TITLE
Allow for passing a logger object into AWS from connection.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,7 +335,8 @@ module.exports = (function () {
           "accessKeyId": connection.accessKeyId,
           "secretAccessKey": connection.secretAccessKey,
           "region": connection.region,
-          "endpoint": connection.endPoint
+          "endpoint": connection.endPoint,
+	  "logger": connection.logger
         });
       } catch (e) {
         


### PR DESCRIPTION
tested//passed, does not breaking existing if connection/adapter does not have a logger defined.

...useful, helped debug setup.
