### PR TITLE
Get tests to run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "mocha": "~1.13.0",
-    "waterline-adapter-tests": "~0.10.0",
+    "waterline-adapter-tests": "~0.10.7",
     "captains-log": "~0.11.1"
   },
   "waterlineAdapter": {
@@ -38,7 +38,8 @@
       "semantic",
       "queryable",
       "associations"
-    ]
+    ],
+    "features": []
   },
   "bugs": {
     "url": "https://github.com/gadelkareem/sails-dynamodb/issues"

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -5,30 +5,24 @@ var util = require('util');
 var mocha = require('mocha');
 var log = new (require('captains-log'))();
 
-
 var TestRunner = require('waterline-adapter-tests');
 var Adapter = require('../../');
-
-
 
 // Grab targeted interfaces from this adapter's `package.json` file:
 var package = {};
 var interfaces = [];
 try {
-    package = require('root-require')('package.json');
-    interfaces = package['sailsAdapter'].implements;
+    package = require('../../package.json');
+    interfaces = package.waterlineAdapter.interfaces;
+    features = package.waterlineAdapter.features;
 }
 catch (e) {
     throw new Error(
     '\n'+
     'Could not read supported interfaces from "sails-adapter"."interfaces"'+'\n' +
     'in this adapter\'s `package.json` file ::' + '\n' +
-    util.inspect(e)
-    );
+    util.inspect(e));
 }
-
-
-
 
 
 log.info('Testing `' + package.name + '`, a Sails adapter.');
@@ -38,8 +32,6 @@ console.log();
 log('Latest draft of Waterline adapter interface spec:');
 log('https://github.com/balderdashy/sails-docs/blob/master/adapter-specification.md');
 console.log();
-
-
 
 
 /**
@@ -54,30 +46,33 @@ new TestRunner({
     // Load the adapter module.
     adapter: Adapter,
 
-    // Default adapter config to use.
-    config: {
-        schema: false
+    mocha: {
+      bail: true
     },
+
+    // Default adapter config to use.
+    config: {},
 
     // The set of adapter interfaces to test against.
     // (grabbed these from this adapter's package.json file above)
-    interfaces: interfaces
-    
+    interfaces: interfaces,
+    features: features
+
     // Most databases implement 'semantic' and 'queryable'.
-    // 
+    //
     // As of Sails/Waterline v0.10, the 'associations' interface
     // is also available.  If you don't implement 'associations',
     // it will be polyfilled for you by Waterline core.  The core
     // implementation will always be used for cross-adapter / cross-connection
     // joins.
-    // 
+    //
     // In future versions of Sails/Waterline, 'queryable' may be also
     // be polyfilled by core.
-    // 
+    //
     // These polyfilled implementations can usually be further optimized at the
     // adapter level, since most databases provide optimizations for internal
     // operations.
-    // 
+    //
     // Full interface reference:
     // https://github.com/balderdashy/sails-docs/blob/master/adapter-specification.md
 });


### PR DESCRIPTION
Updated the test running so that it doesn't error-out.  We should continue working on this so that it is easy to test the adapter.  If we can get it to pass the adapter tests, it wouldn't be out of the question to ask waterline if it could be a waterline-sanctioned adapter.

Please don't merge quite yet.  I will take related work/PRs on devinivy/sails-dynamodb `test-running` branch that will get funneled into this PR.
