### PR TITLE
Fixed missing lodash dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "vogels": "~0.12.0",
-    "lodash": "",
+    "lodash": "^3.10.1",
     "async": ""
   },
   "devDependencies": {


### PR DESCRIPTION
By leaving out the version in the lodash dependency the recently released lodash 4.0 has introduced a breaking change.
