### PR TITLE
added new method to make where queries consistent with mongodb adapter

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ module.exports = (function () {
           "secretAccessKey": connection.secretAccessKey,
           "region": connection.region,
           "endpoint": connection.endPoint,
-    "logger": connection.logger
+          "logger": connection.logger
         });
       } catch (e) {
         


### PR DESCRIPTION
Use case example:

model.findOne().where({
    and: [
        { 'title': 'My Title' },
        { 'tag': 'my-tag'   }
    ]
}.exec(function findCB(err, found) {
    // Do stuff
});
