### PR TITLE
Creates tables at startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,6 +212,15 @@ module.exports = (function () {
       
       // Cache Vogels model
       _vogelsReferences[collectionName] = vogelsModel;
+
+      Vogels.createTables(function (err) {
+        if (err) {
+          console.log('Error creating tables: ', err);
+        } else {
+          console.log('Tables have been created');
+        }
+      });
+
       
       return vogelsModel;
       
@@ -925,6 +934,7 @@ module.exports = (function () {
       var current = Model.create(values, function (err, res) {
         if (err) {
           //sails.log.error(__filename + ", create error:", err);
+          err.stack = '';
           cb(err);
         }
         else {


### PR DESCRIPTION
Added stack attribute to err object to prevent exception in Water Line

Does not update table definition if schema/key changes.

It is recommended that you assign: primaryKey:true to your primary key field or by default primaryKey will be id field.